### PR TITLE
Update local install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ GATSBY_EZAC_API_URL=<https://dev.ezac.nl> OR <https://ezac.nl>
 
 ### Run locally
 ```
-npm install --legacy-peerdeps
+npm install --legacy-peer-deps
 npm start
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ GATSBY_EZAC_API_URL=<https://dev.ezac.nl> OR <https://ezac.nl>
 
 ### Run locally
 ```
-npm install
+npm install --legacy-peerdeps
 npm start
 ```
 


### PR DESCRIPTION
Added `--legacy-peer-deps` switch to `npm install` step in Readme 
This prevents React conflicts with Gatsby